### PR TITLE
fix incorrect capitalization of scaling and requirement names

### DIFF
--- a/Data/weapons.json
+++ b/Data/weapons.json
@@ -9046,29 +9046,29 @@
       ],
       "scalesWith":[
          {
-            "name":"STR",
+            "name":"Str",
             "scaling":"E"
          },
          {
-            "name":"DEX",
+            "name":"Dex",
             "scaling":"C"
          },
          {
-            "name":"INT",
+            "name":"Int",
             "scaling":"E"
          }
       ],
       "requiredAttributes":[
          {
-            "name":"STR",
+            "name":"Str",
             "amount":8
          },
          {
-            "name":"DEX",
+            "name":"Dex",
             "amount":18
          },
          {
-            "name":"INT",
+            "name":"Int",
             "amount":16
          }
       ],
@@ -24483,7 +24483,7 @@
             "scaling":"D"
          },
          {
-            "name":"DEX",
+            "name":"Dex",
             "scaling":"D"
          }
       ],
@@ -24493,7 +24493,7 @@
             "amount":22
          },
          {
-            "name":"DEX",
+            "name":"Dex",
             "amount":12
          }
       ],


### PR DESCRIPTION
I noticed this weapon was broken in the bot and found these were all caps instead of first letter caps like the rest

![image](https://user-images.githubusercontent.com/22659210/235252625-a0c7dd96-3b3c-4154-918f-6b119b2abd1a.png)